### PR TITLE
Support allowing swipe cells and other gesture recognizers exclusively

### DIFF
--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -16,10 +16,10 @@ import UIKit
 open class SwipeTableViewCell: UITableViewCell {
     /// The object that acts as the delegate of the `SwipeTableViewCell`.
     public weak var delegate: SwipeTableViewCellDelegate?
-    
+
     var animator: SwipeAnimator?
 
-    var state = SwipeState.center
+    open var state = SwipeState.center
     var originalCenter: CGFloat = 0
     
     weak var tableView: UITableView?
@@ -128,7 +128,10 @@ open class SwipeTableViewCell: UITableViewCell {
                 let velocity = gesture.velocity(in: target)
                 let orientation: SwipeActionsOrientation = velocity.x > 0 ? .left : .right
 
-                showActionsView(for: orientation)
+                if !showActionsView(for: orientation) {
+                    panGestureRecognizer.isEnabled = false
+                    panGestureRecognizer.isEnabled = true
+                }
             }
             
         case .changed:

--- a/Source/Swipeable.swift
+++ b/Source/Swipeable.swift
@@ -19,7 +19,7 @@ protocol Swipeable {
 
 extension SwipeTableViewCell: Swipeable {}
 
-enum SwipeState: Int {
+public enum SwipeState: Int {
     case center = 0
     case left
     case right


### PR DESCRIPTION
A couple changes to allow preventing an edge gesture recognizer from working simultaneously with a swipe cells.

- Toggle the gesture recognizer enabled state to properly handle a delegate returning nil from editActionsForRowAt
- Expose SwipeTableViewState so a separate gesture recognizer can avoid starting when cells are not centered
