### PR TITLE
Make gesture recognizer public

### DIFF
--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -27,7 +27,7 @@ open class SwipeTableViewCell: UITableViewCell {
 
     var originalLayoutMargins: UIEdgeInsets = .zero
     
-    lazy var panGestureRecognizer: UIPanGestureRecognizer = {
+    public lazy var panGestureRecognizer: UIPanGestureRecognizer = {
         let gesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan(gesture:)))
         gesture.delegate = self
         return gesture


### PR DESCRIPTION
So that the viewcontroller using this can add a dependency of another gesture recognizer to fail before this gets triggered.

Fixing this bug https://github.com/superhuman/superhuman-ios/issues/2270