### PR TITLE
Fixes recursive idempotent actions

### DIFF
--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -412,14 +412,16 @@ class SwipeController: NSObject {
             return
         }
 
-        action.handler?(action, indexPath)
-
-        if let style = self.performingFillOption?.autoFulFillmentStyle {
-            action.fulfill(with: style)
-        }
+        let fillOption = self.performingFillOption
 
         self.performingAction = nil
         self.performingFillOption = nil
+
+        action.handler?(action, indexPath)
+
+        if let style = fillOption?.autoFulFillmentStyle {
+            action.fulfill(with: style)
+        }
     }
 
     func reset() {


### PR DESCRIPTION
* This fixes a bug caused by a previous fix I had posted here
* The original bug fix did not properly handle swipe actions using a `with` invocation
* In those cases, invoking the action may happen recursively.
* We need to ensure that invoking actions idempotently still works when invocations are recursive